### PR TITLE
fixed tsv_reader so it doesn't include the first row column names

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -23,6 +23,7 @@ def get_X_y_from_file(filename, label_column=3, label_dict=None, limit=None):
     y = []
     with open(filename, 'r') as f:
         tsv_reader = csv.reader(f, delimiter="\t")
+        next(tsv_reader)
         if limit:
             subsample = sorted(list(tsv_reader), key=lambda k: random.random())[:limit]
         else:


### PR DESCRIPTION
I noticed 'author' being a value inside the dictionary returned by get_x_y_from_file. It is because the tsv_reader contains the first row of the tsv which are the column names. so i added 'next(tsv_reader)' to advance it for one row before the rows get appended into X and y. 